### PR TITLE
Bug/14240 Source sprites from layers api

### DIFF
--- a/data/style.json
+++ b/data/style.json
@@ -34,7 +34,7 @@
          "url": "//raw.githubusercontent.com/NYCPlanning/labs-gl-style/master/data/v3.json"
       }
    },
-   "sprite":"https://tiles.planninglabs.nyc/styles/positron/sprite",
+   "sprite":"https://layers-api.planninglabs.nyc/static/sprite",
    "glyphs":"https://tiles.planninglabs.nyc/fonts/{fontstack}/{range}.pbf",
    "layers":[
       {


### PR DESCRIPTION
# Description

The upgraded basemap server does not contain the sprites that several applications relied on. Consequently, applications which pointed to the basemap server for their sprites received 404s. This dependency on the basemap-server is configured in the labs-gl-style style.json. Applications which are impacted by this change include
- [tax-lot-selector](https://github.com/NYCPlanning/labs-tax-lot-selector/blob/8ce1b4db9be2518dd05473ec7852ce4b5695df4d/js/scripts.js#L12)
- [metro-explorer](https://github.com/NYCPlanning/labs-regional-viz/blob/6bf7875fcfdd31f1c86c18713297be815ea0cbee/app/templates/components/map-from-id.hbs#L4)
- [home](https://github.com/NYCPlanning/labs-home/blob/15ba9bfa69bb96c64fc608912284b18db9360af8/src/pages/community-breakfast.js#L18)
- [map-print-service](https://github.com/NYCPlanning/labs-mapboxgl-print-service/blob/bf2038e315f0e1f21ec34355f4cfb07e75eb3a2a/routes/config.js#L8)

Tax lot selector appears to be the only application whose behavior changed because of the sprite 404s. The other applications did not appear to change their behavior. The reverse is also true; fixing the sprite reference fixes the tax-lot-selector and does not change the behavior of the other applications.

[Waterfront access](https://github.com/NYCPlanning/labs-waterfront-access/blob/ecfeba9ad85173838a1a2118befdb4588f269bf4/public/v1/layer-groups#L2463) and a [few other applications](https://github.com/search?q=org%3ANYCPlanning%20labs-gl-style&type=code) appear to have references to labs-gl-style. However, their run-times appear to be not impacted.

## Tickets
[AB#14240](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14240)

